### PR TITLE
Don't attempt to merge PRs that are not mergable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ requiredStatuses:
   - jenkins
 ```
 
-By default, Merge when green will only require the `cicleci` and `travis-ci` checks.
+By default, Merge when green will wait for [branch protection](https://help.github.com/en/articles/about-protected-branches)
+to pass and also require `circleci` and `travis-ci` before attempting to merge.
 
 Merge when green also allows you to ensure that all requested reviews have approved the pull request. Just add the 
 following to your `.github/merge-when-green.yml`:

--- a/src/mergeWhenGreen.ts
+++ b/src/mergeWhenGreen.ts
@@ -5,6 +5,8 @@ import { getConfiguration } from './configuration'
 
 export default async function mergeWhenGreen (context: Context, pr: Github.PullsGetResponse) {
   if (!hasMergeLabel(pr)) return
+  if (!pr.mergeable) return
+
   if (!(await isEveryCheckSuccessful(context, pr))) return
   if (!(await isEveryStatusSuccessful(context, pr))) return
   if (!(await requestedReviewsComplete(context, pr))) return

--- a/src/mergeWhenGreen.ts
+++ b/src/mergeWhenGreen.ts
@@ -3,20 +3,7 @@ import Github from '@octokit/rest' // eslint-disable-line no-unused-vars
 import { MERGE_LABEL } from './constants'
 import { getConfiguration } from './configuration'
 
-/* eslint-disable no-undef, no-unused-vars */
-/**
- * This represents the properties of a PR we require in order to merge it.
- * It's required because there are multiple ways to get a PR from Github, and their types do not overlap.
- * eg. Github.PullsGetResponse and Github.ReposListPullRequestsAssociatedWithCommitResponseItem
- */
-interface PullType {
-  number: number
-  head: { ref: string }
-  labels: { name: string }[]
-}
-/* eslint-enable no-undef, no-unused-vars */
-
-export default async function mergeWhenGreen (context: Context, pr: PullType) {
+export default async function mergeWhenGreen (context: Context, pr: Github.PullsGetResponse) {
   if (!hasMergeLabel(pr)) return
   if (!(await isEveryCheckSuccessful(context, pr))) return
   if (!(await isEveryStatusSuccessful(context, pr))) return
@@ -25,9 +12,9 @@ export default async function mergeWhenGreen (context: Context, pr: PullType) {
   await mergeAndDeleteBranch(context, pr)
 }
 
-const hasMergeLabel = (pr: PullType): boolean => pr.labels.some((label) => label.name === MERGE_LABEL)
+const hasMergeLabel = (pr: Github.PullsGetResponse) : boolean => pr.labels.some((label) => label.name === MERGE_LABEL)
 
-const isEveryCheckSuccessful = async (context: Context, pr: PullType): Promise<boolean> => {
+const isEveryCheckSuccessful = async (context: Context, pr: Github.PullsGetResponse): Promise<boolean> => {
   const checkRuns = (await context.github.checks.listForRef(
     context.repo({ ref: pr.head.ref })
   )).data.check_runs
@@ -61,7 +48,7 @@ const isEveryCheckSuccessful = async (context: Context, pr: PullType): Promise<b
   )
 }
 
-const isEveryStatusSuccessful = async (context: Context, pr: PullType): Promise<boolean> => {
+const isEveryStatusSuccessful = async (context: Context, pr: Github.PullsGetResponse): Promise<boolean> => {
   const statuses = (await context.github.repos.listStatusesForRef(
     context.repo({ ref: pr.head.ref })
   )).data
@@ -89,7 +76,7 @@ const isEveryStatusSuccessful = async (context: Context, pr: PullType): Promise<
   )
 }
 
-const requestedReviewsComplete = async (context: Context, pr: PullType): Promise<boolean> => {
+const requestedReviewsComplete = async (context: Context, pr: Github.PullsGetResponse): Promise<boolean> => {
   const { requireApprovalFromRequestedReviewers } = await getConfiguration(context)
   if (!requireApprovalFromRequestedReviewers) {
     return Promise.resolve(true)
@@ -104,7 +91,7 @@ const requestedReviewsComplete = async (context: Context, pr: PullType): Promise
   return requestedReviews.users.length === 0 && requestedReviews.teams.length === 0
 }
 
-const mergeAndDeleteBranch = async (context: Context, pr: PullType): Promise<void> => {
+const mergeAndDeleteBranch = async (context: Context, pr: Github.PullsGetResponse): Promise<void> => {
   const result = await context.github.pulls.merge(
     context.repo({ pull_number: pr.number })
   )

--- a/src/mergeWhenGreen.ts
+++ b/src/mergeWhenGreen.ts
@@ -4,8 +4,8 @@ import { MERGE_LABEL } from './constants'
 import { getConfiguration } from './configuration'
 
 export default async function mergeWhenGreen (context: Context, pr: Github.PullsGetResponse) {
-  if (!hasMergeLabel(pr)) return
   if (!pr.mergeable) return
+  if (!hasMergeLabel(pr)) return
 
   if (!(await isEveryCheckSuccessful(context, pr))) return
   if (!(await isEveryStatusSuccessful(context, pr))) return

--- a/src/statusSuccessHandler.ts
+++ b/src/statusSuccessHandler.ts
@@ -5,11 +5,15 @@ import mergeWhenGreen from './mergeWhenGreen'
 export default async function statusSuccessHandler (context: Context) {
   if (context.payload.state !== 'success') return
 
-  const prs = (await context.github.repos.listPullRequestsAssociatedWithCommit(
+  const associatedPrs = (await context.github.repos.listPullRequestsAssociatedWithCommit(
     context.repo({ commit_sha: context.payload.sha })
   )).data
 
-  await Promise.all(prs.map(async (pr: Github.ReposListPullRequestsAssociatedWithCommitResponseItem) => {
+  await Promise.all(associatedPrs.map(async (prRef: Github.ReposListPullRequestsAssociatedWithCommitResponseItem) => {
+    const pr = (await context.github.pulls.get(
+      context.repo({ pull_number: prRef.number })
+    )).data
+
     await mergeWhenGreen(context, pr)
   }))
 }

--- a/test/mergeWhenGreen.test.ts
+++ b/test/mergeWhenGreen.test.ts
@@ -39,10 +39,9 @@ beforeEach(() => {
   }
 })
 
-test('skip when no merge label', async () => {
+test('skip not mergeable', async () => {
   const pr: any = {
-    mergeable: true,
-    labels: []
+    mergeable: false
   }
   await mergeWhenGreen(context, pr)
 
@@ -52,10 +51,10 @@ test('skip when no merge label', async () => {
   expect(context.github.git.deleteRef).not.toHaveBeenCalled()
 })
 
-test('skip not mergeable', async () => {
+test('skip when no merge label', async () => {
   const pr: any = {
-    mergeable: false,
-    labels: [MERGE_LABEL]
+    mergeable: true,
+    labels: []
   }
   await mergeWhenGreen(context, pr)
 

--- a/test/mergeWhenGreen.test.ts
+++ b/test/mergeWhenGreen.test.ts
@@ -40,7 +40,23 @@ beforeEach(() => {
 })
 
 test('skip when no merge label', async () => {
-  const pr: any = {labels: []}
+  const pr: any = {
+    mergeable: true,
+    labels: []
+  }
+  await mergeWhenGreen(context, pr)
+
+  expect(context.github.checks.listForRef).not.toHaveBeenCalled()
+  expect(context.github.repos.listStatusesForRef).not.toHaveBeenCalled()
+  expect(context.github.pulls.merge).not.toHaveBeenCalled()
+  expect(context.github.git.deleteRef).not.toHaveBeenCalled()
+})
+
+test('skip not mergeable', async () => {
+  const pr: any = {
+    mergeable: false,
+    labels: [MERGE_LABEL]
+  }
   await mergeWhenGreen(context, pr)
 
   expect(context.github.checks.listForRef).not.toHaveBeenCalled()
@@ -55,6 +71,7 @@ test('skip when failing checks but passing statuses', async () => {
 
   const pr: any = {
     number: 1,
+    mergeable: true,
     labels: [{name: MERGE_LABEL}],
     head: {
       ref: '3efb1d'
@@ -86,6 +103,7 @@ test('skip when failing checks but passing statuses', async () => {
   })
   await mergeWhenGreen(context, pr)
 
+  expect(context.github.checks.listForRef).toHaveBeenCalled()
   expect(context.github.pulls.merge).not.toHaveBeenCalled()
   expect(context.github.git.deleteRef).not.toHaveBeenCalled()
 })
@@ -96,6 +114,7 @@ test('skip when missing checks but passing statuses', async () => {
 
   const pr: any = {
     number: 1,
+    mergeable: true,
     labels: [{name: MERGE_LABEL}],
     head: {
       ref: '3efb1d'
@@ -121,6 +140,7 @@ test('skip when missing checks but passing statuses', async () => {
   })
   await mergeWhenGreen(context, pr)
 
+  expect(context.github.checks.listForRef).toHaveBeenCalled()
   expect(context.github.pulls.merge).not.toHaveBeenCalled()
   expect(context.github.git.deleteRef).not.toHaveBeenCalled()
 })
@@ -131,6 +151,7 @@ test('skip when passing checks but failing statuses', async () => {
 
   const pr: any = {
     number: 1,
+    mergeable: true,
     labels: [{name: MERGE_LABEL}],
     head: {
       ref: '3efb1d'
@@ -159,6 +180,7 @@ test('skip when passing checks but failing statuses', async () => {
   })
   await mergeWhenGreen(context, pr)
 
+  expect(context.github.repos.listStatusesForRef).toHaveBeenCalled()
   expect(context.github.pulls.merge).not.toHaveBeenCalled()
   expect(context.github.git.deleteRef).not.toHaveBeenCalled()
 })
@@ -169,6 +191,7 @@ test('skip when passing checks but missing statuses', async () => {
 
   const pr: any = {
     number: 1,
+    mergeable: true,
     labels: [{name: MERGE_LABEL}],
     head: {
       ref: '3efb1d'
@@ -192,6 +215,7 @@ test('skip when passing checks but missing statuses', async () => {
   })
   await mergeWhenGreen(context, pr)
 
+  expect(context.github.repos.listStatusesForRef).toHaveBeenCalled()
   expect(context.github.pulls.merge).not.toHaveBeenCalled()
   expect(context.github.git.deleteRef).not.toHaveBeenCalled()
 })
@@ -260,6 +284,7 @@ test('merge pull requests when passing checks and statuses', async () => {
 
   const pr: any = {
     number: 1,
+    mergeable: true,
     labels: [{name: MERGE_LABEL}],
     head: {
       ref: '3efb1d'
@@ -282,6 +307,8 @@ test('merge pull requests when passing checks and statuses', async () => {
 
   await mergeWhenGreen(context, pr)
 
+  expect(context.github.checks.listForRef).toHaveBeenCalled()
+  expect(context.github.repos.listStatusesForRef).toHaveBeenCalled()
   expect(context.github.pulls.merge).toHaveBeenCalled()
   expect(context.github.git.deleteRef).toHaveBeenCalled()
 })

--- a/test/mergeWhenGreen.test.ts
+++ b/test/mergeWhenGreen.test.ts
@@ -318,6 +318,7 @@ test('merge pull requests when passing checks and statuses and all requested rev
 
   const pr: any = {
     number: 1,
+    mergeable: true,
     labels: [{name: MERGE_LABEL}],
     head: {
       ref: '3efb1d'

--- a/test/statusSuccessHandler.test.ts
+++ b/test/statusSuccessHandler.test.ts
@@ -9,6 +9,9 @@ beforeEach(() => {
     github: {
       repos: {
         listPullRequestsAssociatedWithCommit: jest.fn()
+      },
+      pulls: {
+        get: jest.fn()
       }
     },
     payload: {
@@ -32,19 +35,36 @@ test('does not call mergeWhenGreen when the status was not successful', async ()
 
   await statusSuccessHandler(context)
 
+  expect(context.github.pulls.get).not.toBeCalled()
   expect(mergeWhenGreen).not.toBeCalled()
 })
 
 test('calls mergeWhenGreen for all pull requests related to the status', async () => {
-  const prs = [{ number: 1 }, { number: 2 }]
+  let pr1 = { number: 1 }
+  let pr2 = { number: 2 }
+  const associatedPrs = [pr1, pr2]
 
   context.github.repos.listPullRequestsAssociatedWithCommit.mockResolvedValue({
-    data: prs
+    data: associatedPrs
   })
+
+  context.github.pulls.get.mockImplementation((pr: { pull_number: number }) => {
+    if (pr.pull_number === pr1.number) {
+      return Promise.resolve({ data: pr1 })
+    }
+
+    if (pr.pull_number === pr2.number) {
+      return Promise.resolve({ data: pr2 })
+    }
+
+    throw new Error('Unexpected pull number')
+  })
+
   await statusSuccessHandler(context)
 
-  expect(mergeWhenGreen).toBeCalledTimes(prs.length)
-  prs.map((pr) => {
-    expect(mergeWhenGreen).toBeCalledWith(context, pr)
-  })
+  expect(context.github.pulls.get).toBeCalledTimes(2)
+
+  expect(mergeWhenGreen).toBeCalledTimes(associatedPrs.length)
+  expect(mergeWhenGreen).toBeCalledWith(context, pr1)
+  expect(mergeWhenGreen).toBeCalledWith(context, pr2)
 })


### PR DESCRIPTION
As I mentioned in [#36 (comment)](https://github.com/phstc/probot-merge-when-green/issues/36#issuecomment-517968820) in order to ensure we always have the `mergeable` property, I had to make the statusSuccessHandler do another request so I had to remove the interface I created.

Looking at the [GitHub API docs](https://developer.github.com/v3/pulls/#response-1), GitHub is actually creating a merge commit in order to get the `mergeable` property. [This part of the docs](https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests) says 

> A test merge commit is created when you view the pull request in the UI and the "Merge" button is displayed, or when you get, create, or edit a pull request using the REST API.

Which tells me that it does indeed work for branch protection as well.

Closes: #36