### PR TITLE
Add option for requireApprovalFromRequestedReviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ requiredStatuses:
 
 By default, Merge when green will only require the `cicleci` and `travis-ci` checks.
 
+Merge when green also allows you to ensure that all requested reviews have approved the pull request. Just add the 
+following to your `.github/merge-when-green.yml`:
+
+```yaml
+requireApprovalFromRequestedReviewers: true
+```
+
 #### Travis CI and CicleCI
 
 To work with Travis CI and CicleCI make sure GitHub Checks are enabled.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,5 +22,9 @@ export async function getConfiguration (context: Context): Promise<any> {
     config.requiredStatuses = []
   }
 
+  if (config.requireApprovalFromRequestedReviewers === null) {
+    config.requireApprovalFromRequestedReviewers = false
+  }
+
   return {...config, isDefaultConfig: false}
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,6 +4,7 @@ import { CONFIGURATION_FILE } from './constants'
 const defaultConfig = {
   requiredChecks: ['circleci', 'travis-ci'],
   requiredStatuses: [],
+  requireApprovalFromRequestedReviewers: false,
   isDefaultConfig: true
 }
 

--- a/test/mergeWhenGreen.test.ts
+++ b/test/mergeWhenGreen.test.ts
@@ -63,8 +63,7 @@ test('skip when failing checks but passing statuses', async () => {
 
   mockConfiguration = {
     requiredChecks: checks,
-    requiredStatuses: statuses,
-    requireApprovalFromRequestedReviewers: false
+    requiredStatuses: statuses
   }
 
   context.github.repos.listStatusesForRef.mockResolvedValue(getSuccessStatuses(statuses))
@@ -105,8 +104,7 @@ test('skip when missing checks but passing statuses', async () => {
 
   mockConfiguration = {
     requiredChecks: checks,
-    requiredStatuses: statuses,
-    requireApprovalFromRequestedReviewers: false
+    requiredStatuses: statuses
   }
 
   context.github.repos.listStatusesForRef.mockResolvedValue(getSuccessStatuses(statuses))
@@ -141,8 +139,7 @@ test('skip when passing checks but failing statuses', async () => {
 
   mockConfiguration = {
     requiredChecks: checks,
-    requiredStatuses: statuses,
-    requireApprovalFromRequestedReviewers: false
+    requiredStatuses: statuses
   }
 
   context.github.checks.listForRef.mockResolvedValue(getSuccessChecks(checks))
@@ -180,8 +177,7 @@ test('skip when passing checks but missing statuses', async () => {
 
   mockConfiguration = {
     requiredChecks: checks,
-    requiredStatuses: statuses,
-    requireApprovalFromRequestedReviewers: false
+    requiredStatuses: statuses
   }
 
   context.github.checks.listForRef.mockResolvedValue(getSuccessChecks(checks))
@@ -272,8 +268,7 @@ test('merge pull requests when passing checks and statuses', async () => {
 
   mockConfiguration = {
     requiredChecks: checks,
-    requiredStatuses: statuses,
-    requireApprovalFromRequestedReviewers: false
+    requiredStatuses: statuses
   }
 
   context.github.checks.listForRef.mockResolvedValue(getSuccessChecks(checks))
@@ -306,7 +301,7 @@ test('merge pull requests when passing checks and statuses and all requested rev
   mockConfiguration = {
     requiredChecks: checks,
     requiredStatuses: statuses,
-    requireApprovalFromRequestedReviewers: false
+    requireApprovalFromRequestedReviewers: true
   }
 
   context.github.checks.listForRef.mockResolvedValue(getSuccessChecks(checks))


### PR DESCRIPTION
It turns out that I wasn't able to just filter reviews by not `PENDING` as I originally intended in https://github.com/phstc/probot-merge-when-green/issues/42#issue-476398744. As shown in the docs for [create a review](https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review), the `PENDING` state means you haven't submitted your review yet.

However, I tested on one of my repositories and the [list review requests](https://developer.github.com/v3/pulls/review_requests/#list-review-requests) api only returns users or teams that have not submitted a review yet. 

I had a pull request with:
- 2 requested reviewers on it
- One reviewer had approved the pull request
- The other had not

The API only returned the user that had not submitted a review.

Closes: #42

This will cause merge conflicts with #44, but I'll rebase and resolve the conflicts after one of these is merged. It doesn't matter which one goes first.