### PR TITLE
Add ability to configure merge_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ following to your `.github/merge-when-green.yml`:
 requireApprovalFromRequestedReviewers: true
 ```
 
+You can change method that Merge when green uses to merge pull requests with the `mergeMethod` option. Valid values are 
+`merge`, `squash` and `rebase`, the default is `merge`.
+
+```yaml
+mergeMethod: squash
+```
+
 #### Travis CI and CicleCI
 
 To work with Travis CI and CicleCI make sure GitHub Checks are enabled.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,7 +31,7 @@ export async function getConfiguration (context: Context): Promise<any> {
     config.requiredStatuses = []
   }
 
-  if (config.mergeMethod === null || !validMergeMethods.includes(config.mergeMethod)) {
+  if (!validMergeMethods.includes(config.mergeMethod)) {
     config.mergeMethod = 'merge'
   }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,9 +4,18 @@ import { CONFIGURATION_FILE } from './constants'
 const defaultConfig = {
   requiredChecks: ['circleci', 'travis-ci'],
   requiredStatuses: [],
+  mergeMethod: 'merge',
   requireApprovalFromRequestedReviewers: false,
   isDefaultConfig: true
 }
+
+// Specified mergeMethod must be one of the following
+// https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
+const validMergeMethods = [
+  'merge',
+  'squash',
+  'rebase'
+]
 
 export async function getConfiguration (context: Context): Promise<any> {
   const config = await context.config(CONFIGURATION_FILE)
@@ -20,6 +29,10 @@ export async function getConfiguration (context: Context): Promise<any> {
 
   if (config.requiredStatuses === null) {
     config.requiredStatuses = []
+  }
+
+  if (config.mergeMethod === null || !validMergeMethods.includes(config.mergeMethod)) {
+    config.mergeMethod = 'merge'
   }
 
   if (config.requireApprovalFromRequestedReviewers === null) {

--- a/src/mergeWhenGreen.ts
+++ b/src/mergeWhenGreen.ts
@@ -105,8 +105,10 @@ const requestedReviewsComplete = async (context: Context, pr: PullType): Promise
 }
 
 const mergeAndDeleteBranch = async (context: Context, pr: PullType): Promise<void> => {
+  const { mergeMethod } = await getConfiguration(context)
+
   const result = await context.github.pulls.merge(
-    context.repo({ pull_number: pr.number })
+    context.repo({ pull_number: pr.number, merge_method: mergeMethod })
   )
 
   if (!result.data.merged) return


### PR DESCRIPTION
At the moment, MWG will merge every pull request with the `merge` method. Depending on how the user has [configured their repo](https://help.github.com/en/articles/configuring-pull-request-merges) this could make MWG entirely unusable for them (if they have disabled merge commits). 

This is a simple backwards compatible change to allow the user to configure the method to use.