### PR TITLE
Test

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+plugins:
+  tslint:
+    enabled: true

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ requiredStatuses:
 
 By default, Merge when green will only require the `cicleci` and `travis-ci` checks.
 
-Merge when green also allows you to ensure that all requested reviews have approved the pull request. Just add the 
+Merge when green also allows you to ensure that all requested reviews have approved the pull request. Just add the
 following to your `.github/merge-when-green.yml`:
 
 ```yaml
@@ -72,3 +72,4 @@ For more, check out the [Contributing Guide](CONTRIBUTING.md).
 ## License
 
 [ISC](LICENSE) © 2018 Pablo Cantero <pablohstc@gmail.com> (https://github.com/phstc/probot-merge-when-green)
+

--- a/src/mergeWhenGreen.ts
+++ b/src/mergeWhenGreen.ts
@@ -104,7 +104,19 @@ const requestedReviewsComplete = async (context: Context, pr: PullType): Promise
   return requestedReviews.users.length === 0 && requestedReviews.teams.length === 0
 }
 
-const mergeAndDeleteBranch = async (context: Context, pr: PullType): Promise<void> => {
+let mergeAndDeleteBranch = async (context: Context, pr: PullType): Promise<void> => {
+  const result = await context.github.pulls.merge(
+    context.repo({ pull_number: pr.number })
+  )
+
+  if (!result.data.merged) return
+
+  await context.github.git.deleteRef(
+    context.repo({ ref: `heads/${pr.head.ref}` })
+  )
+}
+
+mergeAndDeleteBranch = async (context: Context, pr: PullType): Promise<void> => {
   const result = await context.github.pulls.merge(
     context.repo({ pull_number: pr.number })
   )

--- a/test/checkRunCompletedHandler.test.ts
+++ b/test/checkRunCompletedHandler.test.ts
@@ -29,12 +29,12 @@ beforeEach(() => {
 })
 
 test('calls mergeWhenGreen for all pull requests', async () => {
-  const pr = context.payload.check_run.pull_requests[0]
+  // const pr = context.payload.check_run.pull_requests[0]
 
-  context.github.pulls.get.mockResolvedValue({
-    data: pr
-  })
-  await checkRunCompletedHandler(context)
+  // context.github.pulls.get.mockResolvedValue({
+  //   data: pr
+  // })
+  // await checkRunCompletedHandler(context)
 
   expect(mergeWhenGreen).toBeCalledWith(context, pr)
 })

--- a/test/checkRunCompletedHandler.test.ts
+++ b/test/checkRunCompletedHandler.test.ts
@@ -29,12 +29,12 @@ beforeEach(() => {
 })
 
 test('calls mergeWhenGreen for all pull requests', async () => {
-  // const pr = context.payload.check_run.pull_requests[0]
+  const pr = context.payload.check_run.pull_requests[0]
 
-  // context.github.pulls.get.mockResolvedValue({
-  //   data: pr
-  // })
-  // await checkRunCompletedHandler(context)
+  context.github.pulls.get.mockResolvedValue({
+    data: pr
+  })
+  await checkRunCompletedHandler(context)
 
   expect(mergeWhenGreen).toBeCalledWith(context, pr)
 })


### PR DESCRIPTION
Test for https://github.com/phstc/probot-merge-when-green/pull/44/files#r311071466

### With branch protection and failing tests

![image](https://user-images.githubusercontent.com/105652/62546662-e5cf7f00-b831-11e9-9cfe-a44971a3af97.png)

![image](https://user-images.githubusercontent.com/105652/62546673-ea943300-b831-11e9-8fe0-f85fe73721da.png)


```ruby
client.pull_request('phstc/probot-merge-when-green', 52)

# :mergeable=>true,
# :mergeable_state=>"blocked",

=> true
```

### Without branch protection and failing tests

![image](https://user-images.githubusercontent.com/105652/62546810-321abf00-b832-11e9-82c7-f821dec8af09.png)

```ruby
client.pull_request('phstc/probot-merge-when-green', 52)

# :mergeable=>true,
# :rebaseable=>true,
# :mergeable_state=>"unstable",
```

### Without branch protection and while checks are running (created, but not completed)

```ruby
client.pull_request('phstc/probot-merge-when-green', 52)

# :mergeable=>true,
# :mergeable_state=>"unstable",
```

### With review required and passing tests

```ruby
client.pull_request('phstc/probot-merge-when-green', 52)

# :mergeable_state=>"blocked",
```