### PR TITLE
Fix checking statuses behavior

### DIFF
--- a/src/mergeWhenGreen.ts
+++ b/src/mergeWhenGreen.ts
@@ -62,9 +62,9 @@ const isEveryCheckSuccessful = async (context: Context, pr: PullType): Promise<b
 }
 
 const isEveryStatusSuccessful = async (context: Context, pr: PullType): Promise<boolean> => {
-  const statuses = (await context.github.repos.listStatusesForRef(
+  const statuses = (await context.github.repos.getCombinedStatusForRef(
     context.repo({ ref: pr.head.ref })
-  )).data
+  )).data.statuses
 
   const { requiredStatuses } = await getConfiguration(context)
 
@@ -72,7 +72,7 @@ const isEveryStatusSuccessful = async (context: Context, pr: PullType): Promise<
 
   const uniqMatches = new Set()
 
-  const supportedStatuses = statuses.filter((statusItem: Github.ReposListStatusesForRefResponseItem) => {
+  const supportedStatuses = statuses.filter((statusItem: Github.ReposGetCombinedStatusForRefResponseStatusesItem) => {
     const check = statusItem.context
     if (requiredStatuses.includes(check)) {
       uniqMatches.add(check)
@@ -84,7 +84,7 @@ const isEveryStatusSuccessful = async (context: Context, pr: PullType): Promise<
   if (uniqMatches.size !== requiredStatuses.length) return false
 
   return supportedStatuses.every(
-    (statusItem: Github.ReposListStatusesForRefResponseItem) =>
+    (statusItem: Github.ReposGetCombinedStatusForRefResponseStatusesItem) =>
       statusItem.state === 'success'
   )
 }


### PR DESCRIPTION
`listStatusesForRef` returns the history of statuses of a ref, so there may be multiple statuses for a specific context, e.g. initially `pending` then `success` for `jenkins` context. This is not what we want. Instead we can use `getCombinedStatusForRef` to get the final statuses of a ref.

- https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
- https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
  - > The most recent status for each context is returned, up to 100.

Ref: #41 