### PR TITLE
GitHub Action check

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Merge when green supports both Checks and Statuses. You can configure which ones
 requiredChecks:
   - circleci
   - travis-ci
+# - github # For custom GitHub Action check
 requiredStatuses:
   - jenkins
 ```


### PR DESCRIPTION
Hello 👋 ,

First of all, thanks for this awesome app! We use it on many repos at @lewagon, such a time saver once a PR is reviewed and approved but we are still waiting on CI 🙃 

We are in the process of migrating from Travis to GitHub Actions for our checks and I spent some time figuring out what to put in the `.github/merge-when-green.yml`. By checking the GitHub API (`https://api.github.com/repos/lewagon/www/commits/:sha/check-runs`) and this code:

https://github.com/phstc/probot-merge-when-green/blob/a9cc0801d05e44359adb1ee1cc1ddb11dd5340d4/src/mergeWhenGreen.ts#L31

The JSON response of the API yield `github`.

My proposal is to add this to the `README.md` for future reference of someone wanting to use your GitHub app with a GitHub Action CI setup.

Cheers!